### PR TITLE
:recycle: Create hook to clean Main component

### DIFF
--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -23,25 +23,25 @@ const Main = () => {
   const theme = useTheme();
 
   const [comparisonType, setComparisonType] = useState("table");
-  const { isComparisonModeOn } = useMain();
+  const { isComparisonModeEnabled } = useMain();
 
   return (
     <Styles.MainContainer>
       <Modal />
 
       <Sidebar
-        isComparisonMode={isComparisonModeOn}
+        isComparisonMode={isComparisonModeEnabled}
         title={selected?.properties.NM_MUN}
       />
 
       <Styles.ComparisonWrapper isSidebarOpen={isSidebarOpen} theme={theme}>
         <Header
-          isComparisonModeOn={isComparisonModeOn}
+          isComparisonModeOn={isComparisonModeEnabled}
           comparisonType={comparisonType}
           setComparisonType={setComparisonType}
         />
 
-        {isComparisonModeOn && (
+        {isComparisonModeEnabled && (
           <CompatisonMode comparisonType={comparisonType} />
         )}
       </Styles.ComparisonWrapper>

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -1,67 +1,29 @@
-import { useEffect, useState } from "react";
-import { useLocation, useHistory } from "react-router";
+import { useState } from "react";
 
 import { useTheme } from "@mui/material/styles";
 
-import { useComparison } from "@store/comparisonContext";
 import { useSelectedDistrict } from "@store/district/selectedContext";
 import { useSidebar } from "@store/sidebarContext";
 
+import Map from "@components/Map";
+import Modal from "@components/Modal";
 import Footer from "@components/Footer";
 import Header from "@components/Header";
-import Modal from "@components/Modal";
 import Sidebar from "@components/Sidebar";
 import CompatisonMode from "@components/ComparisonMode";
 
-import Map from "@components/Map";
+import { useMain } from "./hook";
 
 import * as Styles from "./styles";
 
 const Main = () => {
-  const { comparison, addComparisonDistrict } = useComparison();
-  const { isSidebarOpen, setIsSidebarOpen } = useSidebar();
-  const { all, selected } = useSelectedDistrict();
-
-  const location = useLocation();
-  const history = useHistory();
+  const { isSidebarOpen } = useSidebar();
+  const { selected } = useSelectedDistrict();
 
   const theme = useTheme();
 
-  const [isComparisonModeOn, setIsComparisonModeOn] = useState<boolean>(false);
   const [comparisonType, setComparisonType] = useState("table");
-
-  useEffect(() => {
-    setIsComparisonModeOn(location.pathname.startsWith("/comparison"));
-  }, [location, setIsComparisonModeOn]);
-
-  useEffect(() => {
-    if (
-      comparison.length === 0 &&
-      location.pathname.startsWith("/comparison/")
-    ) {
-      const pathIds = location.pathname.replace("/comparison/", "");
-      if (pathIds) {
-        const ids = pathIds.split("+");
-        const featuresFromUrl = all.filter((ft: any) =>
-          ids.includes(ft.properties["CD_MUN"].toString())
-        );
-        setIsSidebarOpen(true);
-        addComparisonDistrict(featuresFromUrl);
-      } else {
-        history.replace("/");
-      }
-    }
-  }, [location, history, comparison, addComparisonDistrict]);
-
-  useEffect(() => {
-    if (location.pathname.startsWith("/comparison/") && all.length !== 0) {
-      const ids = comparison.map((feature: any) => feature.properties.CD_MUN);
-      const newPath = "/comparison/" + ids.join("+");
-      if (location.pathname !== newPath) {
-        history.replace(newPath);
-      }
-    }
-  }, [comparison, location, history]);
+  const { isComparisonModeOn } = useMain();
 
   return (
     <Styles.MainContainer>
@@ -84,7 +46,7 @@ const Main = () => {
         )}
       </Styles.ComparisonWrapper>
 
-      {<Map />}
+      <Map />
 
       <Footer />
     </Styles.MainContainer>

--- a/src/pages/Main/hook/index.ts
+++ b/src/pages/Main/hook/index.ts
@@ -1,0 +1,1 @@
+export { default as useMain } from "./useMain";

--- a/src/pages/Main/hook/useMain.tsx
+++ b/src/pages/Main/hook/useMain.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { useLocation, useHistory } from "react-router";
+
+import { useComparison } from "@store/comparisonContext";
+import { useSelectedDistrict } from "@store/district/selectedContext";
+import { useSidebar } from "@store/sidebarContext";
+
+const useMain = () => {
+  const { comparison, addComparisonDistrict } = useComparison();
+  const { setIsSidebarOpen } = useSidebar();
+  const { all } = useSelectedDistrict();
+
+  const location = useLocation();
+  const history = useHistory();
+
+  const [isComparisonModeOn, setIsComparisonModeOn] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (
+      comparison.length === 0 &&
+      location.pathname.startsWith("/comparison/")
+    ) {
+      const pathIds = location.pathname.replace("/comparison/", "");
+      if (pathIds) {
+        const ids = pathIds.split("+");
+        const featuresFromUrl = all.filter((ft: any) =>
+          ids.includes(ft.properties["CD_MUN"].toString())
+        );
+        setIsSidebarOpen(true);
+        addComparisonDistrict(featuresFromUrl);
+      } else {
+        history.replace("/");
+      }
+    }
+  }, [location, history, comparison]);
+
+  useEffect(() => {
+    if (location.pathname.startsWith("/comparison/") && all.length !== 0) {
+      const ids = comparison.map((feature: any) => feature.properties.CD_MUN);
+      const newPath = "/comparison/" + ids.join("+");
+      if (location.pathname !== newPath) {
+        history.replace(newPath);
+      }
+    }
+  }, [comparison, location, history]);
+
+  useEffect(() => {
+    setIsComparisonModeOn(location.pathname.startsWith("/comparison"));
+  }, [location]);
+
+  return {
+    isComparisonModeOn,
+  };
+};
+
+export default useMain;

--- a/src/pages/Main/hook/useMain.tsx
+++ b/src/pages/Main/hook/useMain.tsx
@@ -13,7 +13,8 @@ const useMain = () => {
   const location = useLocation();
   const history = useHistory();
 
-  const [isComparisonModeOn, setIsComparisonModeOn] = useState<boolean>(false);
+  const [isComparisonModeEnabled, setIsComparisonModeEnabled] =
+    useState<boolean>(false);
 
   useEffect(() => {
     if (
@@ -45,11 +46,11 @@ const useMain = () => {
   }, [comparison, location, history]);
 
   useEffect(() => {
-    setIsComparisonModeOn(location.pathname.startsWith("/comparison"));
+    setIsComparisonModeEnabled(location.pathname.startsWith("/comparison"));
   }, [location]);
 
   return {
-    isComparisonModeOn,
+    isComparisonModeEnabled,
   };
 };
 


### PR DESCRIPTION
## Description

In mind with addition of new components in the platform, was needed to refactor the Main component where aggregate all the component as a only page platform.

## Changes

- Create hook `useMain`
- Pass all `useEffect` of `location` to the hook
- Rename `isComparisonModeOn` to `isComparisonModeEnabled`