### PR TITLE
Update popup

### DIFF
--- a/src/components/Map/hook/useDistrictLayer/districtActions.ts
+++ b/src/components/Map/hook/useDistrictLayer/districtActions.ts
@@ -24,7 +24,7 @@ function addPopup(feature: Feature, map: mapboxgl.Map, type: string) {
 
   switch (type) {
     case 'hover':
-      hoveredPopup.setLngLat([coordinates[0], coordinates[1]]).setHTML(`<h5>${regionName}</h5>`).addTo(map);
+      hoveredPopup.trackPointer().setHTML(`<h5>${regionName}</h5>`).addTo(map);
       break;
     case 'click':
       clickedPopup.setLngLat([coordinates[0], coordinates[1]]).setHTML(`<h5>${regionName}</h5>`).addTo(map);

--- a/src/components/Map/hook/useStateLayer/stateActions.ts
+++ b/src/components/Map/hook/useStateLayer/stateActions.ts
@@ -14,7 +14,7 @@ function addPopup(feature: Feature, map: mapboxgl.Map) {
   const coordinates = turf.centerOfMass(feature).geometry.coordinates;
   const regionName = feature?.properties?.NM_UF;
 
-  hoveredPopup.setLngLat([coordinates[0], coordinates[1]]).setHTML(`<h5>${regionName}</h5>`).addTo(map);
+  hoveredPopup.trackPointer().setHTML(`<h5>${regionName}</h5>`).addTo(map);
 }
 
 function setFeatureHover(featureID: number, map: mapboxgl.Map, state: boolean) {


### PR DESCRIPTION
## Motivation
- Change the popup behaviour

## Changes
- Popup now follows the cursor 


## Status Checklist

<!-- In the status section, you can mark what you have already done -->

- [x] Popup follows the cursor

## Screenshots

<!-- If you are adding a layout change, you can show the images below -->
In both of them the cursor is in the bottom of Mato Grosso. We can see that the popup only keep up with the cursor on the last one.

|Before|After|
|---|---|
|<img src="https://user-images.githubusercontent.com/65057466/171006631-be96e6bb-3bad-4214-9b04-000c41735a69.png" />|<img src="https://user-images.githubusercontent.com/65057466/171006807-05230ebf-c273-4812-b336-ac79aef89e1f.png" />|

## Testing

<!-- How do we test the implementation? -->

1. Run the application
2. Pass your cursor through the map states or districts. 