### PR TITLE
Add news behaviors on map

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 
 import { useSidebar } from '@store/sidebarContext';
+import { useSelectedState } from '@store/state/selectedContext';
+import { useSelectedDistrict } from '@store/district/selectedContext';
 
 import Drawer from '@components/Drawer';
 
@@ -18,6 +20,11 @@ interface Props {
 
 const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setComparisonType }) => {
   const [openMenu, setOpenMenu] = useState(false);
+
+  const { selected: selectedState } = useSelectedState();
+  const { selected } = useSelectedDistrict();
+
+  console.log(selectedState, selected);
 
   const { isSidebarOpen } = useSidebar();
 
@@ -43,7 +50,11 @@ const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setCompar
     <Styles.HeaderContainer isSidebarOpen={isSidebarOpen}>
       <Styles.HeaderLeftSide>
         <SearchBar />
-        <Styles.ReturnRoute>Oiasdadasdaddss</Styles.ReturnRoute>
+        {selectedState && (
+          <Styles.ReturnRoute>
+            Brasil - {selectedState.properties.NM_UF} {selected && <div>&nbsp;- {selected.properties.NM_MUN}</div>}
+          </Styles.ReturnRoute>
+        )}
       </Styles.HeaderLeftSide>
 
       <Styles.HeaderRightSide>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,11 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-
-import useMap from '@hook/useMap';
 import { useSidebar } from '@store/sidebarContext';
-import { useSelectedState } from '@store/state/selectedContext';
-import { useSelectedDistrict } from '@store/district/selectedContext';
 
 import Drawer from '@components/Drawer';
 
@@ -14,6 +9,7 @@ import ComparisonControl from './ComparisonControl';
 import ProjectInformations from './ProjectInformations';
 
 import * as Styles from './styles';
+import LayerRoute from './LayerRoute';
 
 interface Props {
   isComparisonModeOn: boolean;
@@ -23,62 +19,6 @@ interface Props {
 
 const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setComparisonType }) => {
   const [openMenu, setOpenMenu] = useState(false);
-  const [selectedLayer, setSelectedLayer] = useState('country');
-
-  const { resetMapValues, resetDistrictValues } = useMap();
-  const { selected: selectedState } = useSelectedState();
-  const { selected } = useSelectedDistrict();
-
-  useEffect(() => {
-    if (selected) {
-      setSelectedLayer('district');
-    } else if (selectedState && !selected) {
-      setSelectedLayer('state');
-    } else {
-      setSelectedLayer('country');
-    }
-  }, [selected, selectedState]);
-
-  const returnPath = () => {
-    if (selectedLayer === 'district') {
-      return (
-        <>
-          &nbsp;-&nbsp;
-          <div className="state" onClick={() => resetDistrictValues()}>
-            {selectedState?.properties.NM_UF}
-          </div>
-          &nbsp;-&nbsp;<div className="district">{selected?.properties.NM_MUN}</div>
-        </>
-      );
-    } else if (selectedLayer === 'state') {
-      return (
-        <>
-          &nbsp;-&nbsp;
-          <div className="state" onClick={() => resetDistrictValues()}>
-            {selectedState?.properties.NM_UF}
-          </div>
-        </>
-      );
-    }
-  };
-
-  const returnToPreviousLayer = () => {
-    if (selectedLayer === 'district') {
-      resetDistrictValues();
-    } else if (selectedLayer === 'state') {
-      resetMapValues();
-    }
-  };
-
-  const returnPathButton = () => {
-    if (selectedLayer !== 'country') {
-      return (
-        <Styles.ReturnRouteButton onClick={() => returnToPreviousLayer()}>
-          <ChevronLeftIcon sx={{ color: 'black' }} />
-        </Styles.ReturnRouteButton>
-      );
-    }
-  };
 
   const { isSidebarOpen } = useSidebar();
 
@@ -104,13 +44,7 @@ const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setCompar
     <Styles.HeaderContainer isSidebarOpen={isSidebarOpen}>
       <Styles.HeaderLeftSide>
         <SearchBar />
-        <Styles.ReturnRoute selectedLayer={selectedLayer}>
-          {returnPathButton()}
-          <div className="country" onClick={() => resetMapValues()}>
-            Brasil
-          </div>
-          {returnPath()}
-        </Styles.ReturnRoute>
+        <LayerRoute />
       </Styles.HeaderLeftSide>
 
       <Styles.HeaderRightSide>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useSidebar } from '@store/sidebarContext';
 import { useSelectedState } from '@store/state/selectedContext';
@@ -20,11 +20,41 @@ interface Props {
 
 const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setComparisonType }) => {
   const [openMenu, setOpenMenu] = useState(false);
+  const [selectedLayer, setSelectedLayer] = useState('country');
 
   const { selected: selectedState } = useSelectedState();
   const { selected } = useSelectedDistrict();
 
-  console.log(selectedState, selected);
+  useEffect(() => {
+    if (selected) {
+      setSelectedLayer('district');
+    } else if (selectedState && !selected) {
+      setSelectedLayer('state');
+    } else {
+      setSelectedLayer('country');
+    }
+
+    console.log(selectedLayer, selected, selectedState);
+  }, [selected, selectedState]);
+
+  const returnPath = () => {
+    if (selectedLayer === 'district') {
+      return (
+        <>
+          &nbsp;-&nbsp;
+          <div className="state"> {selectedState?.properties.NM_UF} </div>
+          &nbsp; - <div className="district">{selected?.properties.NM_MUN}</div>
+        </>
+      );
+    } else if (selectedLayer === 'state') {
+      return (
+        <>
+          &nbsp;-&nbsp;
+          <div className="state"> {selectedState?.properties.NM_UF} </div>
+        </>
+      );
+    }
+  };
 
   const { isSidebarOpen } = useSidebar();
 
@@ -50,11 +80,10 @@ const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setCompar
     <Styles.HeaderContainer isSidebarOpen={isSidebarOpen}>
       <Styles.HeaderLeftSide>
         <SearchBar />
-        {selectedState && (
-          <Styles.ReturnRoute>
-            Brasil - {selectedState.properties.NM_UF} {selected && <div>&nbsp;- {selected.properties.NM_MUN}</div>}
-          </Styles.ReturnRoute>
-        )}
+        <Styles.ReturnRoute>
+          <div className="country"> Brasil </div>
+          {returnPath()}
+        </Styles.ReturnRoute>
       </Styles.HeaderLeftSide>
 
       <Styles.HeaderRightSide>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import useMap from '@hook/useMap';
 import { useSidebar } from '@store/sidebarContext';
 import { useSelectedState } from '@store/state/selectedContext';
 import { useSelectedDistrict } from '@store/district/selectedContext';
@@ -22,6 +23,7 @@ const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setCompar
   const [openMenu, setOpenMenu] = useState(false);
   const [selectedLayer, setSelectedLayer] = useState('country');
 
+  const { resetMapValues, resetDistrictValues } = useMap();
   const { selected: selectedState } = useSelectedState();
   const { selected } = useSelectedDistrict();
 
@@ -42,15 +44,19 @@ const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setCompar
       return (
         <>
           &nbsp;-&nbsp;
-          <div className="state"> {selectedState?.properties.NM_UF} </div>
-          &nbsp; - <div className="district">{selected?.properties.NM_MUN}</div>
+          <div className="state" onClick={() => resetDistrictValues()}>
+            {selectedState?.properties.NM_UF}
+          </div>
+          &nbsp;-&nbsp;<div className="district">{selected?.properties.NM_MUN}</div>
         </>
       );
     } else if (selectedLayer === 'state') {
       return (
         <>
           &nbsp;-&nbsp;
-          <div className="state"> {selectedState?.properties.NM_UF} </div>
+          <div className="state" onClick={() => resetDistrictValues()}>
+            {selectedState?.properties.NM_UF}
+          </div>
         </>
       );
     }
@@ -81,7 +87,9 @@ const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setCompar
       <Styles.HeaderLeftSide>
         <SearchBar />
         <Styles.ReturnRoute>
-          <div className="country"> Brasil </div>
+          <div className="country" onClick={() => resetMapValues()}>
+            Brasil
+          </div>
           {returnPath()}
         </Styles.ReturnRoute>
       </Styles.HeaderLeftSide>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -43,6 +43,7 @@ const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setCompar
     <Styles.HeaderContainer isSidebarOpen={isSidebarOpen}>
       <Styles.HeaderLeftSide>
         <SearchBar />
+        <Styles.ReturnRoute>Oiasdadasdaddss</Styles.ReturnRoute>
       </Styles.HeaderLeftSide>
 
       <Styles.HeaderRightSide>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+
 import useMap from '@hook/useMap';
 import { useSidebar } from '@store/sidebarContext';
 import { useSelectedState } from '@store/state/selectedContext';
@@ -35,8 +37,6 @@ const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setCompar
     } else {
       setSelectedLayer('country');
     }
-
-    console.log(selectedLayer, selected, selectedState);
   }, [selected, selectedState]);
 
   const returnPath = () => {
@@ -58,6 +58,24 @@ const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setCompar
             {selectedState?.properties.NM_UF}
           </div>
         </>
+      );
+    }
+  };
+
+  const returnToPreviousLayer = () => {
+    if (selectedLayer === 'district') {
+      resetDistrictValues();
+    } else if (selectedLayer === 'state') {
+      resetMapValues();
+    }
+  };
+
+  const returnPathButton = () => {
+    if (selectedLayer !== 'country') {
+      return (
+        <Styles.ReturnRouteButton onClick={() => returnToPreviousLayer()}>
+          <ChevronLeftIcon sx={{ color: 'black' }} />
+        </Styles.ReturnRouteButton>
       );
     }
   };
@@ -87,6 +105,7 @@ const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setCompar
       <Styles.HeaderLeftSide>
         <SearchBar />
         <Styles.ReturnRoute selectedLayer={selectedLayer}>
+          {returnPathButton()}
           <div className="country" onClick={() => resetMapValues()}>
             Brasil
           </div>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -86,7 +86,7 @@ const Header: React.FC<Props> = ({ isComparisonModeOn, comparisonType, setCompar
     <Styles.HeaderContainer isSidebarOpen={isSidebarOpen}>
       <Styles.HeaderLeftSide>
         <SearchBar />
-        <Styles.ReturnRoute>
+        <Styles.ReturnRoute selectedLayer={selectedLayer}>
           <div className="country" onClick={() => resetMapValues()}>
             Brasil
           </div>

--- a/src/components/Header/LayerRoute/LayerRoute.tsx
+++ b/src/components/Header/LayerRoute/LayerRoute.tsx
@@ -30,18 +30,18 @@ const LayerRoute = () => {
     if (selectedLayer === 'district') {
       return (
         <>
-          &nbsp;-&nbsp;
+          <Styles.NextLayer>-</Styles.NextLayer>
           <Button className="place state" onClick={() => resetDistrictValues()}>
             {selectedState?.properties.NM_UF}
           </Button>
-          &nbsp;-&nbsp;
+          <Styles.NextLayer>-</Styles.NextLayer>
           <Button className="place district">{selected?.properties.NM_MUN}</Button>
         </>
       );
     } else if (selectedLayer === 'state') {
       return (
         <>
-          &nbsp;-&nbsp;
+          <Styles.NextLayer>-</Styles.NextLayer>
           <Button className="place state" onClick={() => resetDistrictValues()}>
             {selectedState?.properties.NM_UF}
           </Button>

--- a/src/components/Header/LayerRoute/LayerRoute.tsx
+++ b/src/components/Header/LayerRoute/LayerRoute.tsx
@@ -33,7 +33,8 @@ const LayerRoute = () => {
           <div className="place state" onClick={() => resetDistrictValues()}>
             {selectedState?.properties.NM_UF}
           </div>
-          &nbsp;-&nbsp;<div className="place district">{selected?.properties.NM_MUN}</div>
+          &nbsp;-&nbsp;
+          <div className="place district">{selected?.properties.NM_MUN}</div>
         </>
       );
     } else if (selectedLayer === 'state') {

--- a/src/components/Header/LayerRoute/LayerRoute.tsx
+++ b/src/components/Header/LayerRoute/LayerRoute.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+
+import useMap from '@hook/useMap';
+import { useSelectedState } from '@store/state/selectedContext';
+import { useSelectedDistrict } from '@store/district/selectedContext';
+
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+
+import * as Styles from './styles';
+
+const LayerRoute = () => {
+  const [selectedLayer, setSelectedLayer] = useState('country');
+
+  const { resetMapValues, resetDistrictValues } = useMap();
+  const { selected: selectedState } = useSelectedState();
+  const { selected } = useSelectedDistrict();
+
+  useEffect(() => {
+    if (selected) {
+      setSelectedLayer('district');
+    } else if (selectedState && !selected) {
+      setSelectedLayer('state');
+    } else {
+      setSelectedLayer('country');
+    }
+  }, [selected, selectedState]);
+
+  const returnPath = () => {
+    if (selectedLayer === 'district') {
+      return (
+        <>
+          &nbsp;-&nbsp;
+          <div className="state" onClick={() => resetDistrictValues()}>
+            {selectedState?.properties.NM_UF}
+          </div>
+          &nbsp;-&nbsp;<div className="district">{selected?.properties.NM_MUN}</div>
+        </>
+      );
+    } else if (selectedLayer === 'state') {
+      return (
+        <>
+          &nbsp;-&nbsp;
+          <div className="state" onClick={() => resetDistrictValues()}>
+            {selectedState?.properties.NM_UF}
+          </div>
+        </>
+      );
+    }
+  };
+
+  const returnToPreviousLayer = () => {
+    if (selectedLayer === 'district') {
+      resetDistrictValues();
+    } else if (selectedLayer === 'state') {
+      resetMapValues();
+    }
+  };
+
+  const returnPathButton = () => {
+    if (selectedLayer !== 'country') {
+      return (
+        <Styles.ReturnRouteButton onClick={() => returnToPreviousLayer()}>
+          <ChevronLeftIcon sx={{ color: 'black' }} />
+        </Styles.ReturnRouteButton>
+      );
+    }
+  };
+
+  return (
+    <Styles.ReturnRoute selectedLayer={selectedLayer}>
+      {returnPathButton()}
+      <div className="country" onClick={() => resetMapValues()}>
+        Brasil
+      </div>
+      {returnPath()}
+    </Styles.ReturnRoute>
+  );
+};
+
+export default LayerRoute;

--- a/src/components/Header/LayerRoute/LayerRoute.tsx
+++ b/src/components/Header/LayerRoute/LayerRoute.tsx
@@ -30,17 +30,17 @@ const LayerRoute = () => {
       return (
         <>
           &nbsp;-&nbsp;
-          <div className="state" onClick={() => resetDistrictValues()}>
+          <div className="place state" onClick={() => resetDistrictValues()}>
             {selectedState?.properties.NM_UF}
           </div>
-          &nbsp;-&nbsp;<div className="district">{selected?.properties.NM_MUN}</div>
+          &nbsp;-&nbsp;<div className="place district">{selected?.properties.NM_MUN}</div>
         </>
       );
     } else if (selectedLayer === 'state') {
       return (
         <>
           &nbsp;-&nbsp;
-          <div className="state" onClick={() => resetDistrictValues()}>
+          <div className="place state" onClick={() => resetDistrictValues()}>
             {selectedState?.properties.NM_UF}
           </div>
         </>
@@ -69,7 +69,7 @@ const LayerRoute = () => {
   return (
     <Styles.ReturnRoute selectedLayer={selectedLayer}>
       {returnPathButton()}
-      <div className="country" onClick={() => resetMapValues()}>
+      <div className="place country" onClick={() => resetMapValues()}>
         Brasil
       </div>
       {returnPath()}

--- a/src/components/Header/LayerRoute/LayerRoute.tsx
+++ b/src/components/Header/LayerRoute/LayerRoute.tsx
@@ -4,6 +4,7 @@ import useMap from '@hook/useMap';
 import { useSelectedState } from '@store/state/selectedContext';
 import { useSelectedDistrict } from '@store/district/selectedContext';
 
+import { Button } from '@mui/material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 
 import * as Styles from './styles';
@@ -30,20 +31,20 @@ const LayerRoute = () => {
       return (
         <>
           &nbsp;-&nbsp;
-          <div className="place state" onClick={() => resetDistrictValues()}>
+          <Button className="place state" onClick={() => resetDistrictValues()}>
             {selectedState?.properties.NM_UF}
-          </div>
+          </Button>
           &nbsp;-&nbsp;
-          <div className="place district">{selected?.properties.NM_MUN}</div>
+          <Button className="place district">{selected?.properties.NM_MUN}</Button>
         </>
       );
     } else if (selectedLayer === 'state') {
       return (
         <>
           &nbsp;-&nbsp;
-          <div className="place state" onClick={() => resetDistrictValues()}>
+          <Button className="place state" onClick={() => resetDistrictValues()}>
             {selectedState?.properties.NM_UF}
-          </div>
+          </Button>
         </>
       );
     }
@@ -70,9 +71,9 @@ const LayerRoute = () => {
   return (
     <Styles.ReturnRoute selectedLayer={selectedLayer}>
       {returnPathButton()}
-      <div className="place country" onClick={() => resetMapValues()}>
+      <Button className="place country" onClick={() => resetMapValues()}>
         Brasil
-      </div>
+      </Button>
       {returnPath()}
     </Styles.ReturnRoute>
   );

--- a/src/components/Header/LayerRoute/index.tsx
+++ b/src/components/Header/LayerRoute/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './LayerRoute';

--- a/src/components/Header/LayerRoute/styles.ts
+++ b/src/components/Header/LayerRoute/styles.ts
@@ -32,8 +32,6 @@ export const ReturnRoute = styled.div<IReturnRoute>`
     border-radius: 5px;
     &:hover {
       background-color: rgb(239, 239, 239, 0.3);
-      /* background-color: rgb(239, 239, 239); */
-      /* opacity: 0.1; */
     }
   }
 `;

--- a/src/components/Header/LayerRoute/styles.ts
+++ b/src/components/Header/LayerRoute/styles.ts
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+
+interface IReturnRoute {
+  selectedLayer: string;
+}
+
+export const ReturnRoute = styled.div<IReturnRoute>`
+  font-size: 20px;
+  white-space: nowrap;
+  margin-left: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  cursor: pointer;
+  pointer-events: auto;
+
+  .country {
+    font-weight: ${({ selectedLayer }) => (selectedLayer === 'country' ? 'bold' : 'normal')};
+  }
+
+  .state {
+    font-weight: ${({ selectedLayer }) => (selectedLayer === 'state' ? 'bold' : 'normal')};
+  }
+
+  .district {
+    font-weight: ${({ selectedLayer }) => (selectedLayer === 'district' ? 'bold' : 'normal')};
+  }
+`;
+
+export const ReturnRouteButton = styled.div`
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  background-color: white;
+  margin-right: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/components/Header/LayerRoute/styles.ts
+++ b/src/components/Header/LayerRoute/styles.ts
@@ -50,7 +50,7 @@ export const ReturnRouteButton = styled.div`
   align-items: center;
 
   &:hover {
-    background-color: black;
+    background-color: #509e2f;
 
     svg {
       color: white;

--- a/src/components/Header/LayerRoute/styles.ts
+++ b/src/components/Header/LayerRoute/styles.ts
@@ -57,3 +57,9 @@ export const ReturnRouteButton = styled.div`
     }
   }
 `;
+
+export const NextLayer = styled.div`
+  margin-right: 2px;
+  margin-left: 2px;
+  font-size: 15px;
+`;

--- a/src/components/Header/LayerRoute/styles.ts
+++ b/src/components/Header/LayerRoute/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Button } from '@mui/material';
 
 interface IReturnRoute {
   selectedLayer: string;
@@ -27,9 +28,11 @@ export const ReturnRoute = styled.div<IReturnRoute>`
     font-weight: ${({ selectedLayer }) => (selectedLayer === 'district' ? 'bold' : 'normal')};
   }
 
-  .place {
+  Button {
     padding: 5px;
+    color: white;
     border-radius: 5px;
+    font-size: 15px;
     &:hover {
       background-color: rgb(239, 239, 239, 0.3);
     }

--- a/src/components/Header/LayerRoute/styles.ts
+++ b/src/components/Header/LayerRoute/styles.ts
@@ -5,9 +5,9 @@ interface IReturnRoute {
 }
 
 export const ReturnRoute = styled.div<IReturnRoute>`
-  font-size: 20px;
+  font-size: 15px;
   white-space: nowrap;
-  margin-left: 50px;
+  margin-left: 30px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -26,6 +26,16 @@ export const ReturnRoute = styled.div<IReturnRoute>`
   .district {
     font-weight: ${({ selectedLayer }) => (selectedLayer === 'district' ? 'bold' : 'normal')};
   }
+
+  .place {
+    padding: 5px;
+    border-radius: 5px;
+    &:hover {
+      background-color: rgb(239, 239, 239, 0.3);
+      /* background-color: rgb(239, 239, 239); */
+      /* opacity: 0.1; */
+    }
+  }
 `;
 
 export const ReturnRouteButton = styled.div`
@@ -37,4 +47,12 @@ export const ReturnRouteButton = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  &:hover {
+    background-color: black;
+
+    svg {
+      color: white;
+    }
+  }
 `;

--- a/src/components/Header/LayerRoute/styles.ts
+++ b/src/components/Header/LayerRoute/styles.ts
@@ -29,7 +29,7 @@ export const ReturnRoute = styled.div<IReturnRoute>`
   }
 
   Button {
-    padding: 5px;
+    padding: 0px 5px;
     color: white;
     border-radius: 5px;
     font-size: 15px;

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -66,6 +66,9 @@ export const HeaderRightSide = styled.div`
 `;
 
 export const ReturnRoute = styled.div`
+  font-size: 20px;
+  white-space: nowrap;
+  margin-left: 50px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -92,3 +92,14 @@ export const ReturnRoute = styled.div<IReturnRoute>`
     font-weight: ${({ selectedLayer }) => (selectedLayer === 'district' ? 'bold' : 'normal')};
   }
 `;
+
+export const ReturnRouteButton = styled.div`
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  background-color: white;
+  margin-right: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -50,6 +50,7 @@ export const HeaderLeftSide = styled.div`
   grid-column: 1;
   justify-self: start;
   align-self: center;
+  display: flex;
 `;
 
 export const HeaderCenterSide = styled.div`
@@ -62,4 +63,11 @@ export const HeaderRightSide = styled.div`
   grid-column: 3;
   justify-self: end;
   align-self: center;
+`;
+
+export const ReturnRoute = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
 `;

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -7,6 +7,10 @@ interface HeaderProps {
   isSidebarOpen: boolean;
 }
 
+interface IReturnRoute {
+  selectedLayer: string;
+}
+
 export const HeaderContainer = styled.header<HeaderProps>`
   width: ${({ isSidebarOpen }) => (isSidebarOpen ? 'calc(100% - 385px)' : 'calc(100% - 40px)')};
 
@@ -65,7 +69,7 @@ export const HeaderRightSide = styled.div`
   align-self: center;
 `;
 
-export const ReturnRoute = styled.div`
+export const ReturnRoute = styled.div<IReturnRoute>`
   font-size: 20px;
   white-space: nowrap;
   margin-left: 50px;
@@ -75,4 +79,16 @@ export const ReturnRoute = styled.div`
   color: white;
   cursor: pointer;
   pointer-events: auto;
+
+  .country {
+    font-weight: ${({ selectedLayer }) => (selectedLayer === 'country' ? 'bold' : 'normal')};
+  }
+
+  .state {
+    font-weight: ${({ selectedLayer }) => (selectedLayer === 'state' ? 'bold' : 'normal')};
+  }
+
+  .district {
+    font-weight: ${({ selectedLayer }) => (selectedLayer === 'district' ? 'bold' : 'normal')};
+  }
 `;

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -7,10 +7,6 @@ interface HeaderProps {
   isSidebarOpen: boolean;
 }
 
-interface IReturnRoute {
-  selectedLayer: string;
-}
-
 export const HeaderContainer = styled.header<HeaderProps>`
   width: ${({ isSidebarOpen }) => (isSidebarOpen ? 'calc(100% - 385px)' : 'calc(100% - 40px)')};
 
@@ -68,39 +64,4 @@ export const HeaderRightSide = styled.div`
   grid-column: 3;
   justify-self: end;
   align-self: center;
-`;
-
-export const ReturnRoute = styled.div<IReturnRoute>`
-  font-size: 20px;
-  white-space: nowrap;
-  margin-left: 50px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-  cursor: pointer;
-  pointer-events: auto;
-
-  .country {
-    font-weight: ${({ selectedLayer }) => (selectedLayer === 'country' ? 'bold' : 'normal')};
-  }
-
-  .state {
-    font-weight: ${({ selectedLayer }) => (selectedLayer === 'state' ? 'bold' : 'normal')};
-  }
-
-  .district {
-    font-weight: ${({ selectedLayer }) => (selectedLayer === 'district' ? 'bold' : 'normal')};
-  }
-`;
-
-export const ReturnRouteButton = styled.div`
-  border-radius: 50%;
-  width: 20px;
-  height: 20px;
-  background-color: white;
-  margin-right: 10px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
 `;

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -73,4 +73,6 @@ export const ReturnRoute = styled.div`
   align-items: center;
   justify-content: center;
   color: white;
+  cursor: pointer;
+  pointer-events: auto;
 `;

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -25,6 +25,7 @@ export const HeaderContainer = styled.header<HeaderProps>`
   padding: 15px 20px;
 
   background: ${({ comparisonMode }) => (comparisonMode ? '#ffffffe6' : null)};
+  backdrop-filter: blur(2px);
 `;
 
 interface MenuButtonProps {


### PR DESCRIPTION
## Motivation

- Show the path of the selected element
- Create a return button to navigate between the map
- Blur the header background

## Changes

- Created the path of the current element on header
- Blurred the header background
- Create a return button

## Status Checklist

- [x] Create prototype
- [x] Create return button
- [x] Create path to show current selected element path
- [x] Make the path clickable to navigate between layers

## Screenshots

Prototype: 
![image](https://user-images.githubusercontent.com/38733364/173992801-c8f4c6ef-7bd1-494c-a87c-a328f8b1c8bc.png)

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/38733364/173993179-ac1133bb-5569-426b-ad2a-b6d17959255b.png)|![image](https://user-images.githubusercontent.com/38733364/173993112-7e451638-74d3-4321-9d95-52b36b393983.png)|

## Testing

<!-- How do we test the implementation? -->

- Start the application
- Click in any state
- Click in any district
- Click on return button or in "Brasil" on path
