### PR TITLE
Fixing linter error in CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,9 @@
     "browser": true,
     "es2021": true
   },
+  "globals": {
+    "module": true
+  },
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
@@ -45,7 +48,7 @@
     "jsx-a11y/anchor-is-valid": "off",
     "import/no-unresolved": "off",
     "import/extensions": "off",
-    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
+    "import/no-extraneous-dependencies": ["off", { "devDependencies": true }],
     "jest/expect-expect": "off",
     "react-hooks/rules-of-hooks": "error",
     "react/function-component-definition": "off",

--- a/src/components/Modal/Contributors/Contributors.tsx
+++ b/src/components/Modal/Contributors/Contributors.tsx
@@ -44,7 +44,12 @@ const Contributors = () => {
 
                 <Styles.PersonDatas>
                   <Styles.PersonData>
-                    <Styles.SocialProfileLink hasLink={!!data.socialProfile} href={data.socialProfile} rel="noreferrer" target="_blank">
+                    <Styles.SocialProfileLink
+                      hasLink={!!data.socialProfile}
+                      href={data.socialProfile}
+                      rel="noreferrer"
+                      target="_blank"
+                    >
                       {data.name}
                     </Styles.SocialProfileLink>
                   </Styles.PersonData>

--- a/src/components/Modal/Contributors/styles.ts
+++ b/src/components/Modal/Contributors/styles.ts
@@ -62,10 +62,10 @@ export const PersonData = styled.p`
 export const SocialProfileLink = styled.a<{ hasLink: boolean }>`
   text-decoration: none;
   color: inherit !important;
-  border-bottom: ${({ hasLink }) => hasLink ? '1px solid #54a333' : 'transparent'};
-  cursor: ${({ hasLink }) => hasLink ? 'pointer' : 'text'};;
+  border-bottom: ${({ hasLink }) => (hasLink ? '1px solid #54a333' : 'transparent')};
+  cursor: ${({ hasLink }) => (hasLink ? 'pointer' : 'text')};
   :hover {
-    color: ${({ hasLink }) => hasLink ? '#217100 !important' : ''};
+    color: ${({ hasLink }) => (hasLink ? '#217100 !important' : '')};
   }
 `;
 

--- a/src/config/district/demographic.ts
+++ b/src/config/district/demographic.ts
@@ -55,7 +55,7 @@ const demographicProps: MapPropsSectionType = {
           format: (e: any) => formatValue(e, 'float_3'),
           type: 'none',
         },
-      ]
+      ],
     },
     {
       label: 'HDI_educ',


### PR DESCRIPTION
## Motivation

CI is showing error when executing linter step: yarn lint

## Changes

In the file: `.eslintrc.json`:

- Added a new property called `globals` that informs the linter that a global variable called `module` is being used in the project;

- The `import/no-extraneous-dependencies` property has been disabled. This enables lint to consider as an error any attempt to export modules, either with module.exports, export default, etc. As the export of modules is one of the advantages of using ReactJS, and in this project, it is used in more than 100 files, I believe that the best alternative is to disable this option.

## Status Checklist

- [x] Added a new property called `globals`;
- [x] The `import/no-extraneous-dependencies` property has been disabled;
- [x] The yarn lint:fix command ran successfully;
- [x] The yarn lint command ran successfully;

## Screenshots

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/54580766/203209574-d64ab8e0-5cb7-4b5c-8bd1-4c98633cbd21.png)|![image](https://user-images.githubusercontent.com/54580766/203208936-605a19c9-bd59-478f-8d55-c6220698ea87.png)|
|![image](https://user-images.githubusercontent.com/54580766/203209655-ede41ab0-14c7-430e-a69c-1ef59cfb30f1.png)|![image](https://user-images.githubusercontent.com/54580766/203209060-7db4f752-2f5b-44cd-9846-515f55b45d7e.png)|

## Testing

- In the root of the project, run the command: `yarn lint`

