### PR TITLE
134 white screen bug

### DIFF
--- a/src/components/Sidebar/ComparisonButton/ComparisonButton.tsx
+++ b/src/components/Sidebar/ComparisonButton/ComparisonButton.tsx
@@ -1,11 +1,12 @@
 import { Box } from '@mui/material';
 
-import { useSelectedDistrict } from '@context/district/selectedContext';
 import { useComparison } from '@context/comparisonContext';
+import { useSelectedDistrict } from '@context/district/selectedContext';
 
 import { District } from '@customTypes/district';
 
-import CompareIcon from '../../../assets/utils/compare.svg';
+import { ReactComponent as CompareIcon } from '../../../assets/utils/compare.svg';
+
 import * as Styles from './styles';
 
 const ComparisonButton = () => {

--- a/src/config/react-app.d.ts
+++ b/src/config/react-app.d.ts
@@ -1,0 +1,11 @@
+/*
+  Font: https://github.com/facebook/create-react-app/blob/main/packages/react-scripts/lib/react-app.d.ts#L47
+  Author: facebook/create-react-app
+*/
+
+declare module '*.svg' {
+  export const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+
+  const src: string;
+  export default src;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from 'vite';
 
 import react from '@vitejs/plugin-react';
 
+import svgr from 'vite-plugin-svgr';
 import tsconfigPaths from 'vite-tsconfig-paths';
-import svgr from '@honkhonk/vite-plugin-svgr';
 
 export default defineConfig({
   plugins: [react(), svgr(), tsconfigPaths()],


### PR DESCRIPTION
## Motivation

On the home screen, when clicking on a state and then on one of its cities, the screen turns white, without any information

## Changes

In the file `src/components/Sidebar/ComparisonButton/ComparisonButton.tsx`:
- I changed the svg importation to the format described in the [official documentation](https://github.com/pd4d10/vite-plugin-svgr#readme) of the vite-plugin-svgr lib, which is the one being used in the project;

In the file `vite.config.ts`:
- I changed the svgr library to the library informed in the [official documentation](https://github.com/pd4d10/vite-plugin-svgr#readme);

In the file `src/config/react-app.d.ts`
I added a typescript file that exports a specific module to the svg, so the project stops showing an error when importing any .svg as described in the official documentation

## Status Checklist

- [x] Fixed the bug
- [x] Fixed the error alert when import any .svg image

## Screenshots

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/54580766/208515625-cd27508a-2ce0-47de-9a58-3070e967fd1b.png)|![image](https://user-images.githubusercontent.com/54580766/208515778-7e4786a9-be7f-41bf-9bdc-8d18f7936023.png)|
![image](https://user-images.githubusercontent.com/54580766/208516444-0cecd9fc-9b98-4a31-879d-3f8677dd6d62.png)|![image](https://user-images.githubusercontent.com/54580766/208516507-69208227-e878-4309-9525-77562e63ae1f.png)|

## Testing

- Run the frontend
- Access the url <http://localhost:3000>
- click on a state and then on one of its cities
