### PR TITLE
137 Investigate glit label

### DIFF
--- a/src/components/Map/hook/useStateLayer/stateActions.tsx
+++ b/src/components/Map/hook/useStateLayer/stateActions.tsx
@@ -25,7 +25,7 @@ export function addPopup(feature: Feature, map: mapboxgl.Map, lngLat: mapboxgl.L
       root.render(<ClickablePopup regionName={regionName} reference={map} feature={feature} />);
       clickedPopup.setLngLat(lngLat).setDOMContent(placeholder).addTo(map);
     } else if (type === 'Hover') {
-      hoveredPopup.trackPointer().setHTML(`<h5>${regionName}</h5>`).addTo(map);
+      hoveredPopup.setLngLat(lngLat).setHTML(`<h5>${regionName}</h5>`).addTo(map);
     }
   }
 }


### PR DESCRIPTION
## Motivation

When a user hovers over a state on the map, a popup appears twice: On the map and on the top left corner of the screen.

## Changes

- Replaced the trackPointer() method with the setLngLat() method.

## Screenshots

<!-- If you are adding a layout change, you can show the images below -->

|Before|After|
|---|---|
|<img src="https://user-images.githubusercontent.com/49499946/209013865-65072c49-9e0c-495b-b29d-6e7659acb92f.png" />|<img src="https://user-images.githubusercontent.com/49499946/209013956-610f2bc6-8165-4983-9aff-f50e775790fa.png" />|

## Testing
<!-- How do we test the implementation? -->

- Hover over a state on the map.
