### PR TITLE
108 sidebar for state

### DIFF
--- a/src/components/Header/LayerRoute/LayerRoute.tsx
+++ b/src/components/Header/LayerRoute/LayerRoute.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import useMap from '@hook/useMap';
-import { useSelectedState } from '@context/state/selectedContext';
 import { useSelectedDistrict } from '@context/district/selectedContext';
+import { useSelectedState } from '@context/state/selectedContext';
+import useMap from '@hook/useMap';
 
-import { Button } from '@mui/material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import { Button } from '@mui/material';
 
 import * as Styles from './styles';
 
@@ -14,17 +14,17 @@ const LayerRoute = () => {
 
   const { resetMapValues, resetDistrictValues } = useMap();
   const { selected: selectedState } = useSelectedState();
-  const { selected } = useSelectedDistrict();
+  const { selected: selectedDistrict } = useSelectedDistrict();
 
   useEffect(() => {
-    if (selected) {
+    if (selectedDistrict) {
       setSelectedLayer('district');
-    } else if (selectedState && !selected) {
+    } else if (selectedState && !selectedDistrict) {
       setSelectedLayer('state');
     } else {
       setSelectedLayer('country');
     }
-  }, [selected, selectedState]);
+  }, [selectedDistrict, selectedState]);
 
   const returnPath = () => {
     if (selectedLayer === 'district') {
@@ -35,7 +35,7 @@ const LayerRoute = () => {
             {selectedState?.properties.NM_UF}
           </Button>
           <Styles.NextLayer>-</Styles.NextLayer>
-          <Button className="place district">{selected?.properties.NM_MUN}</Button>
+          <Button className="place district">{selectedDistrict?.properties.NM_MUN}</Button>
         </>
       );
     } else if (selectedLayer === 'state') {

--- a/src/components/Map/hook/useStateLayer/useStateLayer.tsx
+++ b/src/components/Map/hook/useStateLayer/useStateLayer.tsx
@@ -4,23 +4,24 @@ import mapboxgl from 'mapbox-gl';
 
 import geojsonURL from '@data/BR_UF_2020.json';
 
-import { useSelectedState } from '@context/state/selectedContext';
-import { useHighlightedState } from '@context/state/highlightedContext';
 import { useSelectedDistrict } from '@context/district/selectedContext';
+import { useSidebar } from '@context/sidebarContext';
+import { useHighlightedState } from '@context/state/highlightedContext';
+import { useSelectedState } from '@context/state/selectedContext';
 
 import {
-  highlightState,
-  clickState,
-  isStateLayerVisible,
-  cleanStateActions,
-  fitStateCenter,
   addPopup,
+  cleanStateActions,
+  clickState,
+  fitStateCenter,
+  highlightState,
+  isStateLayerVisible,
 } from './stateActions';
 
-import { stateColors } from './const';
 import { fitCenter } from '../../utils/actions';
-import { lineOpacity, lineWidth, fillOpacity } from '../../utils/const';
+import { fillOpacity, lineOpacity, lineWidth } from '../../utils/const';
 import { isDistrictLayerVisible } from '../useDistrictLayer/districtActions';
+import { stateColors } from './const';
 
 const useStateLayer = () => {
   const [stateReference, setStateReference] = useState<mapboxgl.Map>();
@@ -29,6 +30,8 @@ const useStateLayer = () => {
   const { setHighlighted: setHighlightedState, highlighted: highlightedState } = useHighlightedState();
   const { setSelected: setSelectedState, selected: selectedState } = useSelectedState();
   const { selected: selectedDistrict } = useSelectedDistrict();
+
+  const { setIsSidebarOpen } = useSidebar();
 
   function initLayers(reference: mapboxgl.Map) {
     reference.on('load', () => {
@@ -110,8 +113,9 @@ const useStateLayer = () => {
   }, [highlightedState]);
 
   useEffect(() => {
-    if (stateReference && !selectedDistrict) {
+    if (stateReference && selectedState && !selectedDistrict) {
       clickState(selectedState, stateReference);
+      setIsSidebarOpen(true);
 
       if (selectedState) {
         fitStateCenter(selectedState, stateReference);

--- a/src/components/MetricDetails/MetricStateDetails.tsx
+++ b/src/components/MetricDetails/MetricStateDetails.tsx
@@ -1,0 +1,28 @@
+import geosesData from '@data/StateData.json';
+import Bar from './Bar';
+
+const MetricStateDetails = ({ state, metric }: any) => {
+  const renderSingleMetric = () => {
+    // @ts-ignore
+    if (!geosesData[state?.properties.CD_UF]) return;
+
+    // @ts-ignore
+    const rawValue = geosesData[state?.properties.CD_UF][metric.label];
+    const value = metric.format(rawValue);
+
+    switch (metric.type) {
+      case 'bar':
+        return <Bar rawValue={rawValue} metric={metric} id={state.properties.CD_UF} />;
+      default:
+        return (
+          <div key={state.properties.CD_UF}>
+            <data value={rawValue}>{value}</data>
+          </div>
+        );
+    }
+  };
+
+  return <div>{renderSingleMetric()}</div>;
+};
+
+export default MetricStateDetails;

--- a/src/components/MetricDetails/tests/MetricStateDetails.spec.tsx
+++ b/src/components/MetricDetails/tests/MetricStateDetails.spec.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+
+import MetricStateDetails from '../MetricStateDetails';
+
+import { metricBar, metricState, mockData, state } from './mock';
+
+jest.mock('@data/Data.json', () => mockData);
+
+describe('MetricStateDetails component', () => {
+  test('should be able to render the MetricStateDetails component without bar', () => {
+    render(<MetricStateDetails state={state} metric={metricState} />);
+
+    screen.getByText('0,657');
+  });
+
+  test('should be able to render the MetricStateDetails component with Bar', () => {
+    render(<MetricStateDetails state={state} metric={metricBar} />);
+
+    screen.getByText('48%');
+  });
+});

--- a/src/components/MetricDetails/tests/mock.ts
+++ b/src/components/MetricDetails/tests/mock.ts
@@ -31,6 +31,44 @@ export const district = {
   },
 };
 
+export const state = {
+  type: 'Feature',
+  geometry: {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [-61.5838623046875, -8.79822545901635],
+        [-58.414306640625, -8.792796892565548],
+      ],
+    ],
+  },
+  properties: {
+    CD_UF: '51',
+    POPULATION: 3567234,
+    NM_UF: 'Mato Grosso',
+    SIGLA_UF: 'MT',
+    NM_REGIAO: 'Centro-oeste',
+  },
+  id: '51',
+  layer: {
+    id: 'fill-state',
+    type: 'fill',
+    source: 'state',
+    layout: {},
+    paint: {
+      'fill-color': {
+        r: 0.33201690449761273,
+        g: 0.6431253758106562,
+        b: 0.20195187499524705,
+        a: 1,
+      },
+      'fill-opacity': 1,
+    },
+  },
+  source: 'state',
+  state: { hover: true },
+};
+
 export const metric = {
   label: 'IPTUCH(2019)',
   title: 'IPTU',
@@ -46,6 +84,14 @@ export const metricBar = {
   description: 'Dimensão da pobreza (%) - GeoSES',
   format: (e: any) => formatValue(e, 'percent'),
   type: 'bar',
+};
+
+export const metricState = {
+  label: 'HDI_inc',
+  title: 'Índice de Desenvolvimento Humano, dimensão de renda',
+  description: 'Índice de Desenvolvimento Humano, dimensão de renda - GeoSES',
+  format: (e: any) => formatValue(e, 'float2'),
+  type: 'none',
 };
 
 export const mockData = {
@@ -102,5 +148,42 @@ export const mockData = {
     'DISTCAPU(1998)': '267,8277119',
     'POPM(2010)': 6381,
     'POPF(2010)': 6399,
+  },
+};
+
+export const mockStateData = {
+  '51': {
+    MUNICIPIO: "Alta Floresta D'Oeste",
+    Pop_2020: 22728,
+    Frota_2020: 14414,
+    Area_Territorial_km: '7067,127',
+    Populacao_Estimada: 22516,
+    Densidade_demografica: '3,45',
+    Escolarizacao: '95,7',
+    IDHM: '0,641',
+    Mortalidade_infantil: '8,17',
+    Receitas_realizadas: '61193,25696',
+    Despesas_empenhadas: '63500,28264',
+    PIB_per_capita: '21552,47',
+    MUNIC_CODE6: 110001,
+    FU: 11,
+    FU_NAME: 'RONDONIA',
+    LONG: '-61,999824',
+    LAT: '-11,93554',
+    OBSERVED: 308,
+    EXPECTED: '369,7893997',
+    RR_PREV: '0,832889',
+    HDI: '0,641',
+    HDI_educ: '0,526',
+    HDI_long: '0,763',
+    HDI_inc: '0,657',
+    GeoSES: '-0,46844',
+    GeoSESed: '71,44755',
+    GeoSESpv: '48,08146',
+    GeoSESdp: '7,260275',
+    GeoSESwl: '0,144285',
+    GeoSESin: '1601,553',
+    GeoSESsg: '0,085033',
+    'IPTUCH(2019)': 1200,
   },
 };

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -2,18 +2,20 @@ import React from 'react';
 
 import Drawer from '@components/Drawer';
 
-import { Box } from '@mui/material';
 import { AutoStories } from '@mui/icons-material';
+import { Box } from '@mui/material';
 
-import { useSidebar } from '@context/sidebarContext';
 import { useComparison } from '@context/comparisonContext';
 import { useSelectedDistrict } from '@context/district/selectedContext';
+import { useSidebar } from '@context/sidebarContext';
 
-import Minimizer from './Minimizer';
-import RegionDetails from './RegionDetails';
 import ComparisonButton from './ComparisonButton';
 import ComparisonDetails from './ComparisonDetails';
+import Minimizer from './Minimizer';
+import RegionDetails from './RegionDetails';
+import StateDetails from './StateDetails';
 
+import { useSelectedState } from '@context/state/selectedContext';
 import * as Styles from './styles';
 
 interface Props {
@@ -23,15 +25,24 @@ interface Props {
 
 const Sidebar: React.FC<Props> = ({ isComparisonMode, title }) => {
   const { comparison } = useComparison();
-  const { selected } = useSelectedDistrict();
+  const { selected: selectedState } = useSelectedState();
+  const { selected: selectedDistrict } = useSelectedDistrict();
   const { isSidebarOpen, setIsSidebarOpen } = useSidebar();
 
-  const hasSelectedDistrict = Boolean(selected);
+  const hasSelectedState = Boolean(selectedState);
+  const hasSelectedDistrict = Boolean(selectedDistrict);
   const hasComparisonRegions = comparison.length !== 0;
 
   const SidebarContent = () => {
     if (isComparisonMode) {
       return <ComparisonDetails />;
+    } else if ((hasComparisonRegions || hasSelectedState) && !hasSelectedDistrict) {
+      return (
+        <>
+          <Styles.Title>{hasSelectedState ? selectedState?.properties.NM_UF : 'Atlas de Oportunidades'}</Styles.Title>
+          <StateDetails />
+        </>
+      );
     } else if (hasComparisonRegions || hasSelectedDistrict) {
       return (
         <>

--- a/src/components/Sidebar/StateDetails/CollapsibleContent.tsx
+++ b/src/components/Sidebar/StateDetails/CollapsibleContent.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { MapPropsContentType } from '@customTypes/map';
+
+import { Tooltip } from '@mui/material';
+
+import MetricStateDetails from '@components/MetricDetails/MetricStateDetails';
+import { useSelectedState } from '@context/state/selectedContext';
+import * as Styles from './styles';
+
+interface CollapsibleContentProps {
+  props: MapPropsContentType;
+}
+
+export const CollapsibleContent: React.FC<CollapsibleContentProps> = ({ props }) => {
+  const { selected } = useSelectedState();
+  //const { comparison } = useComparison();
+
+  //const isSelectedOnComparison = comparison.some((region) => region.properties.CD_UF === selected?.properties.CD_UF);
+
+  const hasSelectedState = Boolean(selected);
+
+  const { description, title } = props;
+
+  return (
+    <>
+      <Tooltip title={description} arrow>
+        <Styles.PropsTitle>{title}</Styles.PropsTitle>
+      </Tooltip>
+      {/* Caso não seja necessário a comparação entre os Estados, apague estes
+      comentários */}
+      {/* {comparison.map((state) => (
+        <Styles.ValueContent key={state.properties.CD_UF}>
+          <p>{state.properties.FU_NAME}</p>
+          <MetricDetails district={state} metric={props} />
+        </Styles.ValueContent>
+      ))} */}
+
+      {/* {!isSelectedOnComparison && hasSelectedState && (
+        <Styles.ValueContent>
+          <p>{selected?.properties.FU_NAME}</p>
+          <MetricDetails district={selected} metric={props} />
+        </Styles.ValueContent>
+      )} */}
+
+      {hasSelectedState && (
+        <Styles.ValueContent>
+          <p>{selected?.properties.NM_UF}</p>
+          <MetricStateDetails state={selected} metric={props} />
+        </Styles.ValueContent>
+      )}
+    </>
+  );
+};

--- a/src/components/Sidebar/StateDetails/ComparisonSection.tsx
+++ b/src/components/Sidebar/StateDetails/ComparisonSection.tsx
@@ -1,0 +1,34 @@
+import Collapsible from '@components/Collapsible';
+
+import { useComparison } from '@context/comparisonContext';
+
+import * as Styles from './styles';
+
+const ComparisonSection = () => {
+  const { comparison, removeComparisonDistrict } = useComparison();
+
+  const comparisonRegionIds = comparison.map((feature: any) => feature.properties.CD_MUN);
+
+  const ComparisonResult = () => (
+    <Styles.ComparisonButton to={'/comparison/' + comparisonRegionIds.join('+')}>
+      <p>Mostrar comparação</p>
+      <Styles.ChevronIcon />
+    </Styles.ComparisonButton>
+  );
+
+  return (
+    <Collapsible title="Comparação">
+      {comparison.map((feature: any) => (
+        <Styles.ComparisonList key={feature.properties.CD_MUN}>
+          {feature.properties['NM_MUN']}
+          <Styles.CloseIcon onClick={() => removeComparisonDistrict(feature)} />
+        </Styles.ComparisonList>
+      ))}
+
+      {comparison.length > 0 && ComparisonResult()}
+      <Styles.DisclaimerText>Adicione até 4 regiões</Styles.DisclaimerText>
+    </Collapsible>
+  );
+};
+
+export default ComparisonSection;

--- a/src/components/Sidebar/StateDetails/DataSection.tsx
+++ b/src/components/Sidebar/StateDetails/DataSection.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import Collapsible from '@components/Collapsible';
+
+import { useComparison } from '@context/comparisonContext';
+import { useSelectedState } from '@context/state/selectedContext';
+
+import { MapPropsContentType, MapPropsSectionType } from '@customTypes/map';
+
+import { Tooltip } from '@mui/material';
+
+import MetricStateDetails from '@components/MetricDetails/MetricStateDetails';
+import { CollapsibleContent } from './CollapsibleContent';
+import * as Styles from './styles';
+
+const DataSection: React.FC<MapPropsSectionType> = ({ title, content }) => {
+  const { selected } = useSelectedState();
+  const { comparison } = useComparison();
+
+  const isSelectedOnComparison = comparison.some((region) => region.properties.CD_MUN === selected?.properties.CD_UF);
+
+  const hasSelectedState = Boolean(selected);
+
+  return (
+    <Collapsible isTitle={true} title={title}>
+      {content.map((props: MapPropsContentType, id) => (
+        <Styles.PropsWrapper key={id}>
+          {!props.nestedData ? (
+            <CollapsibleContent props={props} />
+          ) : (
+            <>
+              <Collapsible isTitle={false} title={props.title}>
+                {comparison && (
+                  <>
+                    {props.nestedData?.map((data, index) => (
+                      <div key={index}>
+                        <CollapsibleContent props={props} />
+                      </div>
+                    ))}
+                  </>
+                )}
+
+                {!isSelectedOnComparison && !comparison.length && hasSelectedState && (
+                  <>
+                    {props.nestedData.map((data, index) => (
+                      <div key={index}>
+                        <Tooltip title={data.description} arrow>
+                          <Styles.PropsTitle>{data.title}</Styles.PropsTitle>
+                        </Tooltip>
+                        <Styles.ValueContent>
+                          <p>{selected?.properties.NM_UF}</p>
+                          <MetricStateDetails state={selected} metric={props} />
+                        </Styles.ValueContent>
+                      </div>
+                    ))}
+                  </>
+                )}
+              </Collapsible>
+            </>
+          )}
+        </Styles.PropsWrapper>
+      ))}
+    </Collapsible>
+  );
+};
+
+export default DataSection;

--- a/src/components/Sidebar/StateDetails/StateDetails.tsx
+++ b/src/components/Sidebar/StateDetails/StateDetails.tsx
@@ -1,0 +1,23 @@
+import { Box } from '@mui/material';
+
+import districtProps from '@config/district';
+
+import { useComparison } from '@context/comparisonContext';
+
+import ComparisonSection from './ComparisonSection';
+import DataSection from './DataSection';
+
+const StateDetails = () => {
+  const { comparison } = useComparison();
+
+  return (
+    <Box>
+      {comparison.length > 0 && <ComparisonSection />}
+      {districtProps.map((section, id) => (
+        <DataSection key={id} title={section.title} content={section.content} />
+      ))}
+    </Box>
+  );
+};
+
+export default StateDetails;

--- a/src/components/Sidebar/StateDetails/index.tsx
+++ b/src/components/Sidebar/StateDetails/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './StateDetails';

--- a/src/components/Sidebar/StateDetails/styles.ts
+++ b/src/components/Sidebar/StateDetails/styles.ts
@@ -1,0 +1,89 @@
+import styled from 'styled-components';
+
+import { Box } from '@mui/material';
+import { Close, ChevronRight } from '@mui/icons-material';
+
+import { Link } from 'react-router-dom';
+
+export const ComparisonButton = styled(Link)`
+  display: flex;
+  align-items: center;
+  align-self: center;
+
+  margin-top: 20px;
+  padding: 5px 15px;
+
+  background: #ffffff;
+
+  text-decoration: none;
+  text-align: center;
+  font-size: 14px;
+  font-weight: 500;
+  color: #000000;
+
+  box-sizing: border-box;
+  border: 1px solid #000000;
+  border-radius: 100px;
+
+  cursor: pointer;
+
+  p {
+    margin: 0;
+  }
+`;
+
+export const ChevronIcon = styled(ChevronRight)`
+  color: #000000;
+  margin-left: 10px;
+`;
+
+export const CloseIcon = styled(Close)`
+  cursor: pointer;
+  color: rgb(153, 153, 153) #4a7929;
+`;
+
+export const PropsWrapper = styled(Box)`
+  display: flex;
+  flex-direction: column;
+
+  font-size: 14px;
+`;
+
+export const PropsTitle = styled.h2`
+  font-size: 13px;
+
+  margin-top: 12px;
+  margin-bottom: 5px;
+`;
+
+export const ComparisonList = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  margin-top: 15px;
+
+  font-size: 15px;
+`;
+
+export const DisclaimerText = styled.p`
+  text-align: center;
+  font-size: 14px;
+  font-weight: 400;
+  color: #666666;
+
+  margin: 20px 0px 10px;
+`;
+
+export const ValueContent = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+
+  margin-bottom: 5px;
+
+  p {
+    margin: 0;
+  }
+`;

--- a/src/config/state/demographic.ts
+++ b/src/config/state/demographic.ts
@@ -1,0 +1,156 @@
+import { formatValue } from '@utils/formatValue';
+import { MapPropsSectionType } from '@customTypes/map';
+
+const demographicProps: MapPropsSectionType = {
+  title: 'Demográfica (D)',
+  content: [
+    {
+      label: 'OBSERVED',
+      title: 'Número de mortes observadas por causas evitáveis',
+      description: 'Número de mortes observadas por causas evitáveis de 5 a 74 anos (2013 a 2017) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'EXPECTED',
+      title: 'Número de mortes esperadas',
+      description:
+        'Número de mortes esperadas para a distribuição da população de acordo com sexo e grupos de labelade - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'RR_PREV',
+      title: 'Risco relativo de mortalidade por causas evitáveis',
+      description:
+        'Risco relativo de mortallabelade por causas evitáveis de 5 a 74 anos por padronização indireta por sexo e labelade - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'IDHM',
+      title: 'Índice de Desenvolvimento Humano (IDH)',
+      description: 'IDHM - Índice de desenvolvimento humano municipal (2010) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'float_3'),
+      type: 'none',
+      nestedData: [
+        {
+          label: 'IDHM',
+          title: 'Índice de Desenvolvimento Humano (IDH)',
+          description: 'IDHM - Índice de desenvolvimento humano municipal (2010) - IBGE cidades',
+          format: (e: any) => formatValue(e, 'float_3'),
+          type: 'none',
+        },
+        {
+          label: 'HDI_educ',
+          title: 'Índice de Desenvolvimento Humano, dimensão educacional',
+          description: 'Índice de Desenvolvimento Humano, dimensão educacional - GeoSES',
+          format: (e: any) => formatValue(e, 'float_3'),
+          type: 'none',
+        },
+        {
+          label: 'HDI_long',
+          title: 'Índice de Desenvolvimento Humano, dimensão longevidade',
+          description: 'Índice de Desenvolvimento Humano, dimensão longevidade - GeoSES',
+          format: (e: any) => formatValue(e, 'float_3'),
+          type: 'none',
+        },
+      ],
+    },
+    {
+      label: 'HDI_educ',
+      title: 'Índice de Desenvolvimento Humano, dimensão educacional',
+      description: 'Índice de Desenvolvimento Humano, dimensão educacional - GeoSES',
+      format: (e: any) => formatValue(e, 'float_3'),
+      type: 'none',
+    },
+    {
+      label: 'HDI_long',
+      title: 'Índice de Desenvolvimento Humano, dimensão longevidade',
+      description: 'Índice de Desenvolvimento Humano, dimensão longevidade - GeoSES',
+      format: (e: any) => formatValue(e, 'float_3'),
+      type: 'none',
+    },
+    {
+      label: 'GeoSESed',
+      title: 'Dimensão de educação',
+      description: 'Dimensão de educação (%) - GeoSES',
+      format: (e: any) => formatValue(e, 'percent'),
+      type: 'bar',
+    },
+    {
+      label: 'Area_Territorial_km',
+      title: 'Área territorial',
+      description: 'Área Territorial Brasileira km² (2020) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Populacao_Estimada',
+      title: 'População',
+      description: 'População estimada - pessoas (2021) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'population'),
+      type: 'none',
+    },
+    {
+      label: 'Densidade_demografica',
+      title: 'Densidade demográfica',
+      description: 'Densidade demográfica - hab/km² (2010) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Escolarizacao',
+      title: 'Escolarização de 6 a 14 anos',
+      description: 'Escolarização de 6 a 14 anos - % (2010) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'percent'),
+      type: 'bar',
+    },
+    {
+      label: 'Mortalidade_infantil',
+      title: 'Mortalidade infantil',
+      description: 'Mortalidade infantil - óbitos por mil nascidos vivos (2019) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Populacao_no_ultimo_censo(2010)',
+      title: 'População',
+      description: 'População no último censo (2010) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Frota_2020',
+      title: 'Frota de veículos',
+      description:
+        'Frota de automóveis, caminhonetes, camionetas, motocicletas, motonetas e utilitários no ano 2020 - Mobilidados',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'DISTCAPU(1998)',
+      title: 'Distância à capital estadual para os municípios',
+      description:
+        'Distância à capital estadual para os municípios da divisão político administrativa vigente em 2000 - IPEA',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'POPM(2010)',
+      title: 'População Masculina',
+      description: 'População Masculina - IBGE',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'POPF(2010)',
+      title: 'População Feminina',
+      description: 'População Feminina - IBGE',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+  ],
+};
+
+export default demographicProps;

--- a/src/config/state/economic.ts
+++ b/src/config/state/economic.ts
@@ -1,0 +1,133 @@
+import { formatValue } from '@utils/formatValue';
+import { MapPropsSectionType } from '@customTypes/map';
+
+const economicProps: MapPropsSectionType = {
+  title: 'Econômica (E)',
+  content: [
+    {
+      label: 'HDI_inc',
+      title: 'Índice de Desenvolvimento Humano, dimensão de renda',
+      description: 'Índice de Desenvolvimento Humano, dimensão de renda - GeoSES',
+      format: (e: any) => formatValue(e, 'float_3'),
+      type: 'none',
+    },
+    {
+      label: 'GeoSESpv',
+      title: 'Dimensão da pobreza',
+      description: 'Dimensão da pobreza (%) - GeoSES',
+      format: (e: any) => formatValue(e, 'percent'),
+      type: 'bar',
+    },
+    {
+      label: 'GeoSESdp',
+      title: 'Dimensão de privação',
+      description: 'Dimensão de privação (%) - GeoSES',
+      format: (e: any) => formatValue(e, 'percent'),
+      type: 'bar',
+    },
+    {
+      label: 'GeoSESwl',
+      title: 'Dimensão de riqueza (%)',
+      description: 'Dimensão de riqueza (%) - GeoSES',
+      format: (e: any) => formatValue(e, 'percent'),
+      type: 'bar',
+    },
+    {
+      label: 'GeoSESsg',
+      title: 'Dimensão de segregação por raça e renda',
+      description:
+        'Dimensão de segregação por raça e renda (Índice de Concentração nos Extremos, variando de -1 a +1) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'GeoSESin',
+      title: 'Dimensão da renda',
+      description: 'Dimensão da renda (em reais; 1 dólar americano = 1,76 reais em 2010) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Receitas_realizadas',
+      title: 'Receitas',
+      description: 'Receitas realizadas - R$ (×1000) (2017) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Despesas_empenhadas',
+      title: 'Despesas',
+      description: 'Despesas empenhadas - R$ (×1000) (2017) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'PIB_per_capita',
+      title: 'PIB per capita',
+      description: 'PIB per capita - R$ (2018) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Salario_medio_mensal_dos_trabalhadores_formais(2019)',
+      title: 'Salário médio mensal',
+      description: 'Salário médio mensal dos trabalhadores formais (2019) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Pessoal_ocupado(2019)',
+      title: 'Pessoas empregadas',
+      description: 'Número de pessoas empregadas no município (2019) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Populacao_ocupada(2019)',
+      title: 'Percentual da população empregada',
+      description: 'Porcentagem da população empregada (2019) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'percent'),
+      type: 'bar',
+    },
+    {
+      label: 'Percentual_da_populacao_com_rendimento_nominal_mensal_per_capita_de_ate_1/2_salario_minimo(2010)',
+      title: 'Percentual população renda mensal até 1/2 salário mínimo',
+      description:
+        'Percentual da população com rendimento nominal mensal per capita de até 1/2 salário mínimo (2010) - IBGE cidades',
+      format: (e: any) => formatValue(e, 'percent'),
+      type: 'bar',
+    },
+    {
+      label: 'AGENCIAS(2019)',
+      title: 'Número de agências bancárias',
+      description: 'Número de agências bancárias - BCB',
+      format: (e: any) => formatValue(e, 'none'),
+      type: 'none',
+    },
+    {
+      label: 'APLICACOES(2019)',
+      title: 'Aplicações',
+      description: 'Valor corresponde a conta Operações de Crédito - BCB',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+
+    {
+      label: 'POUPANCA(2019)',
+      title: 'Poupança',
+      description: 'Valor corresponde a conta Depósitos de Poupança - BCB',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'IPTUCH(2019)',
+      title: 'IPTU',
+      description:
+        'Destina-se ao registro dos valores do tributo que tem como fato gerador a propriedade, o domínio útil ou a posse de bem imóvel por natureza ou por acessão física, como definido na lei civil, localizado na zona urbana do município, fixada em lei municipal. - IPEA',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+  ],
+};
+
+export default economicProps;

--- a/src/config/state/index.ts
+++ b/src/config/state/index.ts
@@ -1,0 +1,10 @@
+import { MapPropsSectionType } from '@customTypes/map';
+
+import socioeconomicProps from './socioeconomic';
+import demographicProps from './demographic';
+import economicProps from './economic';
+import socialProps from './social';
+
+const districtProps: MapPropsSectionType[] = [demographicProps, socialProps, socioeconomicProps, economicProps];
+
+export default districtProps;

--- a/src/config/state/social.ts
+++ b/src/config/state/social.ts
@@ -1,0 +1,125 @@
+import { formatValue } from '@utils/formatValue';
+import { MapPropsSectionType } from '@customTypes/map';
+
+const socialProps: MapPropsSectionType = {
+  title: 'Social (S)',
+  content: [
+    {
+      label: 'IDEB_anos_iniciais_do_ensino_fundamental(2015)',
+      title: 'IDEB anos iniciais do ensino fundamental',
+      description: 'Índice de Desenvolvimento da Educação Básica - Anos iniciais do ensino fundamental (2010) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'IDEB_anos_finais_do_ensino_fundamental(2015)',
+      title: 'IDEB anos finais do ensino fundamental',
+      description: 'Índice de Desenvolvimento da Educação Básica - Anos iniciais do ensino médio (2010) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Matriculas_no_ensino_fundamental(2020)',
+      title: 'Matriculas no ensino fundamental',
+      description: 'Matrículas no ensino fundamental (2020) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Matriculas_no_ensino_medio(2020)',
+      title: 'Matrículas no ensino médio',
+      description: 'Matrículas no ensino médio (2020) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Docentes_no_ensino_fundamental(2020)',
+      title: 'Docentes no ensino fundamental',
+      description: 'Docentes no ensino fundamental (2020) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Docentes_no_ensino_medio(2020)',
+      title: 'Docentes no ensino médio',
+      description: 'Docentes no ensino médio (2020) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Numero_de_estabelecimentos_de_ensino_fundamental(2020)',
+      title: 'Escolas de ensino fundamental',
+      description: 'Número de escolas de ensino fundamental (2020) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Numero_de_estabelecimentos_de_ensino_medio(2020)',
+      title: 'Escolas de ensino médio',
+      description: 'Número de escolas de ensino médio (2020) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Internacoes_por_diarreia(2016)',
+      title: 'Internações por diarréia ',
+      description: 'Número de internações por diarréia (2016) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Estabelecimentos_de_saude_sus(2009)',
+      title: 'Estabelecimentos de saúde (SUS)',
+      description: 'Estabelecimentos de saúde do SUS (2009) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+    {
+      label: 'Esgotamento_sanitario_adequado(2020)',
+      title: 'Esgotamento sanitário adequado',
+      description:
+        '[População total residente nos domicílios particulares permanentes com esgotamento sanitário do tipo rede geral e fossa séptica / População total residente nos domicílios particulares permanentes] x 100 (2020) - GeoSES',
+      format: (e: any) => formatValue(e, 'percent'),
+      type: 'bar',
+    },
+    {
+      label: 'Arborizacao_de_vias_publicas(2010)',
+      title: 'Arborização de vias públicas',
+      description:
+        '[Domicílios urbanos em face de quadra com arborização/domicílios urbanos totais] x100 (2020) - GeoSES',
+      format: (e: any) => formatValue(e, 'percent'),
+      type: 'bar',
+    },
+    {
+      label: 'Urbanizacao_de_vias_publicas(2010)',
+      title: 'Urbanização de vias públicas',
+      description:
+        '[Domicílios urbanos em face de quadra com boca de lobo e pavimentação e meio-fio e calçada/domicílios urbanos totais] x 100 (2020) - GeoSES',
+      format: (e: any) => formatValue(e, 'percent'),
+      type: 'bar',
+    },
+    {
+      label: 'ACIDT(2019)',
+      title: 'Óbitos causados por acidentes de trânsito',
+      description: 'Óbitos causados por acidentes de trânsito - DATASUS',
+      format: (e: any) => formatValue(e, 'none'),
+      type: 'none',
+    },
+    {
+      label: 'HOMIC(2019)',
+      title: 'Óbitos por homicidio',
+      description: 'Óbitos por homicidio - DATASUS',
+      format: (e: any) => formatValue(e, 'none'),
+      type: 'none',
+    },
+    {
+      label: 'SUICID(2019)',
+      title: 'Óbitos por suicídio',
+      description: 'Óbitos por suicídio - DATASUS',
+      format: (e: any) => formatValue(e, 'none'),
+      type: 'none',
+    },
+  ],
+};
+
+export default socialProps;

--- a/src/config/state/socioeconomic.ts
+++ b/src/config/state/socioeconomic.ts
@@ -1,0 +1,17 @@
+import { formatValue } from '@utils/formatValue';
+import { MapPropsSectionType } from '@customTypes/map';
+
+const socioeconomicProps: MapPropsSectionType = {
+  title: 'Socioeconômico (SE)',
+  content: [
+    {
+      label: 'GeoSES',
+      title: 'Índice socioeconômico',
+      description: 'Índice socioeconômico proposto, variando de -1 a +1 (das piores às melhores condições) - GeoSES',
+      format: (e: any) => formatValue(e, 'float_2'),
+      type: 'none',
+    },
+  ],
+};
+
+export default socioeconomicProps;


### PR DESCRIPTION
## Motivation

Since we have the sidebar for the district layer, we decided to have the same behaviour for the state layer where we should show the specific data collected to this layer

## Changes

- Adding the valid code of a state
- Adding the state config files
- Adding state details component
- Adding metric state details component
- Adding test for metric state details component
- Renaming city and state selection states

## Status Checklist

 - [x] Create state layer structure
 - [x] Create data state structure
 - [x] Create behaviour to should sidebar at first click
 - [x] Create test for the sidebar

## Screenshots

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/54580766/209735609-471f734c-832e-4439-b526-ba94c024d8ee.png)|![image](https://user-images.githubusercontent.com/54580766/209735624-08bcb82d-90ee-4859-ac25-dc11c0ac57c0.png)|

## Testing

- Access the url <http://localhost:3000>
- Click on the state of Mato Grosso (is the only one that has data to be displayed for now)
